### PR TITLE
Remove array prototype

### DIFF
--- a/lib/brainfuck.js
+++ b/lib/brainfuck.js
@@ -4,15 +4,6 @@
 'use strict';
 
 /**
- * top() method for getting the top of a stack
- */
-if (!Array.prototype.top) {
-    Array.prototype.top = function top() {
-        return this[this.length - 1];
-    };
-}
-
-/**
  * STDIN handler
  */
 function _incoming(chunk) {
@@ -74,7 +65,7 @@ function _step(pointer, data, cursor) {
         case '[' :
             // no stack objects or it's pointing to another position
             if (
-                'number' !== typeof (_top = _stack.top())
+                'number' !== typeof (_top = _stack[_stack.length - 1])
                 || _top !== (cursor - 1)
             ) {
                 _stack.push(cursor - 1);
@@ -93,7 +84,7 @@ function _step(pointer, data, cursor) {
             break;
 
         case ']' :
-            if ('number' !== typeof (_top = _stack.top())) {
+            if ('number' !== typeof (_top = _stack[_stack.length - 1])) {
                 this._error = new Error('No preceeding "]"'); // bad syntax
             } else {
                 if (current) { cursor  = _top; } // first char after loop


### PR DESCRIPTION
You have created an array prototype method `top`. There is little point to this method.
```js
if (!Array.prototype.top) {
    Array.prototype.top = function top() {
        return this[this.length - 1];
    };
}
```
You really do not need to make an array prototype to simply *return the last element* of an array. By doing this, you break features such as `for...in`.

There is debate as to whether this is bad practice or not, and I honestly don't care what you do in your own personal workspaces. However, as a public library you are unwittingly breaking other people's projects. Imagine, if you will, somebody adding this as a dependency to their large project. Suddenly, because of the array prototype, it ceases to function. Is saving 26 characters really worth this?